### PR TITLE
Fix: avoid appending '?' when urlParams is empty

### DIFF
--- a/Sources/EventHorizon/Core/Protocols/APIEndpointProtocol.swift
+++ b/Sources/EventHorizon/Core/Protocols/APIEndpointProtocol.swift
@@ -54,8 +54,11 @@ public extension APIEndpointProtocol {
     /// ```
     var urlRequest: URLRequest? {
         var components = URLComponents(string: baseURL + apiVersion + path)
-        components?.queryItems = urlParams.map { key, value in
-            URLQueryItem(name: key, value: String(describing: value))
+        
+        if !urlParams.isEmpty {
+            components?.queryItems = urlParams.map { key, value in
+                URLQueryItem(name: key, value: String(describing: value))
+            }
         }
         
         guard let url = components?.url else { return nil }


### PR DESCRIPTION
This PR fixes a small issue where the generated URLRequest includes a trailing ? in the URL when urlParams is empty. While syntactically valid, this can break certain APIs that do not accept URLs ending with a bare question mark.

