### PR TITLE
feat: add async support to NetworkInterceptorProtocol (non-breaking)

### DIFF
--- a/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
+++ b/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
@@ -86,6 +86,13 @@ public extension NetworkInterceptorProtocol {
     ///   - response: The original `URLResponse` received from the server.
     ///   - data: The raw `Data` returned from the request.
     /// - Returns: A tuple containing the modified response and data.
+    /// Provides a default asynchronous implementation of response interception
+    /// by delegating to the synchronous `intercept(response:data:)` method.
+    ///
+    /// - Parameters:
+    ///   - response: The original `URLResponse` received from the server.
+    ///   - data: The raw `Data` returned from the request.
+    /// - Returns: A tuple containing the modified response and data.
     func interceptAsync(response: URLResponse?, data: Data?) async throws -> (URLResponse?, Data?) {
         intercept(response: response, data: data)
     }

--- a/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
+++ b/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
@@ -79,6 +79,13 @@ public extension NetworkInterceptorProtocol {
         intercept(request: request)
     }
 
+    /// Provides a default asynchronous implementation of response interception
+    /// by delegating to the synchronous `intercept(response:data:)` method.
+    ///
+    /// - Parameters:
+    ///   - response: The original `URLResponse` received from the server.
+    ///   - data: The raw `Data` returned from the request.
+    /// - Returns: A tuple containing the modified response and data.
     func interceptAsync(response: URLResponse?, data: Data?) async throws -> (URLResponse?, Data?) {
         intercept(response: response, data: data)
     }

--- a/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
+++ b/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
@@ -57,7 +57,11 @@ public protocol NetworkInterceptorProtocol: Sendable {
         data: Data?
     ) -> (URLResponse?, Data?)
     
-    // MARK: - Asynchronous API (Optional)
+    /// Asynchronously intercepts and potentially modifies an outgoing network request before it is sent.
+    ///
+    /// - Parameter request: The original `URLRequest` to be sent.
+    /// - Returns: A modified `URLRequest` that will be executed.
+    /// - Throws: An error if interception fails.
     func interceptAsync(request: URLRequest) async throws -> URLRequest
     func interceptAsync(response: URLResponse?, data: Data?) async throws -> (URLResponse?, Data?)
 }

--- a/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
+++ b/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
@@ -63,6 +63,13 @@ public protocol NetworkInterceptorProtocol: Sendable {
     /// - Returns: A modified `URLRequest` that will be executed.
     /// - Throws: An error if interception fails.
     func interceptAsync(request: URLRequest) async throws -> URLRequest
+    /// Asynchronously intercepts and potentially modifies the response received from the network.
+    ///
+    /// - Parameters:
+    ///   - response: The original `URLResponse` received from the server.
+    ///   - data: The raw `Data` returned from the request.
+    /// - Returns: A tuple containing the modified response and data.
+    /// - Throws: An error if interception fails.
     func interceptAsync(response: URLResponse?, data: Data?) async throws -> (URLResponse?, Data?)
 }
 

--- a/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
+++ b/Sources/EventHorizon/Core/Protocols/NetworkInterceptor.swift
@@ -56,4 +56,19 @@ public protocol NetworkInterceptorProtocol: Sendable {
         response: URLResponse?,
         data: Data?
     ) -> (URLResponse?, Data?)
+    
+    // MARK: - Asynchronous API (Optional)
+    func interceptAsync(request: URLRequest) async throws -> URLRequest
+    func interceptAsync(response: URLResponse?, data: Data?) async throws -> (URLResponse?, Data?)
+}
+
+// Default async implementations that just call the sync versions
+public extension NetworkInterceptorProtocol {
+    func interceptAsync(request: URLRequest) async throws -> URLRequest {
+        intercept(request: request)
+    }
+
+    func interceptAsync(response: URLResponse?, data: Data?) async throws -> (URLResponse?, Data?) {
+        intercept(response: response, data: data)
+    }
 }

--- a/Sources/EventHorizon/Infrastructure/Services/APIClient.swift
+++ b/Sources/EventHorizon/Infrastructure/Services/APIClient.swift
@@ -180,7 +180,7 @@ private extension APIClient {
 
         // Apply request interceptors
         for interceptor in interceptors {
-            mutableRequest = interceptor.intercept(request: mutableRequest)
+            mutableRequest = try await interceptor.interceptAsync(request: mutableRequest)
         }
 
         // If a progress delegate is provided, create a new session instance.
@@ -200,7 +200,7 @@ private extension APIClient {
             var modifiedData = data
             var modifiedResponse = response
             for interceptor in interceptors {
-                let result = interceptor.intercept(response: modifiedResponse, data: modifiedData)
+                let result = try await interceptor.interceptAsync(response: modifiedResponse, data: modifiedData)
                 modifiedResponse = result.0 ?? modifiedResponse
                 modifiedData = result.1 ?? modifiedData
             }


### PR DESCRIPTION
### Summary

This PR introduces optional `async` methods to `NetworkInterceptorProtocol`, allowing interceptors to perform asynchronous operations (e.g., fetching tokens, reading from secure storage, logging, etc.). The changes are fully backward-compatible and do not affect existing synchronous interceptors.

### What's New

- Added `interceptAsync(request:) async -> URLRequest` with a default implementation that calls the sync `intercept(request:)`.
- Added `interceptAsync(response:data:) async -> (URLResponse?, Data?)` with a default implementation that calls the sync `intercept(response:data:)`.
- Maintains existing behavior for all current users of the library.

### Why

Swift's concurrency model is now widely adopted (iOS 15+), and many modern use cases (such as Firebase token injection or disk/secure storage access) require asynchronous operations inside interceptors. This update provides the flexibility developers need without introducing breaking changes.

### Example Use Case

```swift
class FirebaseAuthInterceptor: NetworkInterceptorProtocol {
    func interceptAsync(request: URLRequest) async -> URLRequest {
        var request = request
        if let token = try? await Auth.auth().currentUser?.getIDToken() {
            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
        }
        return request
    }
}
